### PR TITLE
Update URL to use github.com/yuzu-mirror instead of github.com/yuzu-emu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update && apt-get -y full-upgrade && \
 COPY . /root/build-files
 
 RUN --mount=type=cache,id=ccache,target=/root/.ccache \
-    git clone --depth 1000 -j4 --recursive https://github.com/yuzu-emu/yuzu-mainline.git /root/yuzu-mainline && \
+    git clone --depth 1000 -j4 --recursive https://github.com/yuzu-mirror/yuzu-mainline.git /root/yuzu-mainline && \
     cd /root/yuzu-mainline && /root/build-files/.ci/build.sh
 
 FROM rootfs-prep AS sliced-deps


### PR DESCRIPTION
The Dockerfile in this repository contains a reference to `github.com/yuzu-emu/yuzu-mainline`, which is now offline.
This PR will replace it with `github.com/yuzu-mirror/yuzu-mainline`.